### PR TITLE
Add tips to swipe requests

### DIFF
--- a/Swipe4MeMobile/SwipeRequests/CreateSwipeRequestView.swift
+++ b/Swipe4MeMobile/SwipeRequests/CreateSwipeRequestView.swift
@@ -11,6 +11,8 @@ import FirebaseCore
 struct CreateSwipeRequestView: View {
     @State var request: SwipeRequest
     @State private var selectedTime = Date()
+    @State private var tipAmountText = ""
+    @State private var showTipSection = false
     @Environment(AuthenticationManager.self) var authManager
     @Environment(\.dismiss) private var dismiss
 
@@ -34,6 +36,30 @@ struct CreateSwipeRequestView: View {
                 }
                 .frame(height: 50)
             }
+            
+            Section {
+                HStack {
+                    Text("Add Tip")
+                    Spacer()
+                    Toggle("", isOn: $showTipSection)
+                }
+                
+                if showTipSection {
+                    HStack {
+                        Text("Amount")
+                        Spacer()
+                        Text("$")
+                        TextField("0.00", text: $tipAmountText)
+                            .keyboardType(.decimalPad)
+                            .multilineTextAlignment(.trailing)
+                            .frame(width: 80)
+                    }
+                }
+            } footer: {
+                if showTipSection {
+                    Text("Optional tip to incentivize swipers. You'll coordinate payment details directly with your swiper.")
+                }
+            }
 
         }
         .navigationTitle("Make a Swipe Request")
@@ -44,6 +70,13 @@ struct CreateSwipeRequestView: View {
                 Button {
                     request.meetingTime = Timestamp(date: selectedTime)
                     request.requesterId = authManager.user?.uid ?? ""
+                    
+                    // Set tip amount if provided
+                    if showTipSection, let tipAmount = Double(tipAmountText), tipAmount > 0 {
+                        request.tipAmount = tipAmount
+                    } else {
+                        request.tipAmount = nil
+                    }
                     
                     dump(request)
                     

--- a/Swipe4MeMobile/SwipeRequests/OpenRequestCardView.swift
+++ b/Swipe4MeMobile/SwipeRequests/OpenRequestCardView.swift
@@ -19,9 +19,21 @@ struct OpenRequestCardView: View {
                 VStack(alignment: .leading, spacing: 5) {
                     Text(request.location.rawValue)
                         .font(.headline)
-                    Text("Meeting at: \(request.meetingTime.dateValue(), style: .time)")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
+                    HStack {
+                        Text(request.meetingTime.dateValue(), style: .time)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        
+                        if let tipAmount = request.tipAmount, tipAmount > 0 {
+                            Text(" | ")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            Text("$\(tipAmount, specifier: "%.0f") Tip")
+                                .font(.subheadline)
+                                .fontWeight(.bold)
+                                .foregroundColor(.green)
+                        }
+                    }
                 }
 
                 Spacer()

--- a/Swipe4MeMobile/SwipeRequests/SwipeRequestCardView.swift
+++ b/Swipe4MeMobile/SwipeRequests/SwipeRequestCardView.swift
@@ -26,9 +26,21 @@ struct SwipeRequestCardView: View {
                 VStack(alignment: .leading, spacing: 5) {
                     Text(request.location.rawValue)
                         .font(.headline)
-                    Text("Meeting at: \(request.meetingTime.dateValue(), style: .time)")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
+                    HStack {
+                        Text(request.meetingTime.dateValue(), style: .time)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        
+                        if let tipAmount = request.tipAmount, tipAmount > 0 {
+                            Text(" | ")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            Text("$\(tipAmount, specifier: "%.0f") Tip")
+                                .font(.subheadline)
+                                .fontWeight(.bold)
+                                .foregroundColor(.green)
+                        }
+                    }
                 }
                 
                 Spacer()

--- a/Swipe4MeMobile/SwipeRequests/SwipeRequestModel.swift
+++ b/Swipe4MeMobile/SwipeRequests/SwipeRequestModel.swift
@@ -18,12 +18,13 @@ struct SwipeRequest: Codable, Identifiable, Equatable, Hashable {
     var cloudTaskNames: CloudTaskNames?
     var requesterReviewCompleted: Bool = false
     var swiperReviewCompleted: Bool = false
+    var tipAmount: Double?
 
     let createdAt: Timestamp
 
     init(
         requesterId: String = "", swiperId: String = "", location: DiningLocation = .commons,
-        meetingTime: Timestamp = Timestamp(), status: RequestStatus = .open
+        meetingTime: Timestamp = Timestamp(), status: RequestStatus = .open, tipAmount: Double? = nil
     ) {
         self.requesterId = requesterId
         self.swiperId = swiperId
@@ -33,6 +34,7 @@ struct SwipeRequest: Codable, Identifiable, Equatable, Hashable {
         self.cloudTaskNames = nil
         self.requesterReviewCompleted = false
         self.swiperReviewCompleted = false
+        self.tipAmount = tipAmount
         self.createdAt = Timestamp()
     }
     


### PR DESCRIPTION
This pull request adds support for including an optional tip amount when creating a swipe request, and updates the UI to display tip information on request cards if provided. The changes span model updates, form logic, and UI enhancements to improve both the creation and viewing of swipe requests with tips.

### Tip feature implementation

* Added a new optional `tipAmount` property to the `SwipeRequest` model and updated its initializer to accept a tip value. (`Swipe4MeMobile/SwipeRequests/SwipeRequestModel.swift`) [[1]](diffhunk://#diff-9ad2299f61f20c5bd6f6ac7e4029bb25f62d46dc01819cc80eb12ba05b069a7aR21-R27) [[2]](diffhunk://#diff-9ad2299f61f20c5bd6f6ac7e4029bb25f62d46dc01819cc80eb12ba05b069a7aR37)
* Modified the create swipe request form to include a toggle and input field for entering a tip amount, with explanatory text shown when enabled. (`Swipe4MeMobile/SwipeRequests/CreateSwipeRequestView.swift`) [[1]](diffhunk://#diff-c215bf8dd5bced69b02c5bcea5927582e1d66b6b8a34337d5e6e91f9c87bd675R14-R15) [[2]](diffhunk://#diff-c215bf8dd5bced69b02c5bcea5927582e1d66b6b8a34337d5e6e91f9c87bd675R40-R63)
* Updated request creation logic to set the `tipAmount` on the request only if a valid value is entered; otherwise, it remains nil. (`Swipe4MeMobile/SwipeRequests/CreateSwipeRequestView.swift`)

### UI enhancements for tip display

* Updated both `SwipeRequestCardView` and `OpenRequestCardView` to show the tip amount in green and bold next to the meeting time if a tip is set and greater than zero. (`Swipe4MeMobile/SwipeRequests/SwipeRequestCardView.swift`, `Swipe4MeMobile/SwipeRequests/OpenRequestCardView.swift`) [[1]](diffhunk://#diff-2448fd8cf0a716a08ec2ebac41e21c672ff30676b8778f4d0364d9ceac446571L29-R43) [[2]](diffhunk://#diff-6c193d31ef051d34008ac5cf00dc76396e39594b9ce0ffa6db30fb1d44693d72L22-R36)